### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mend-sast.yml
+++ b/.github/workflows/mend-sast.yml
@@ -1,5 +1,8 @@
 name: Mend SAST Scan
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/kampalli31/mend-sast-gradle-demo/security/code-scanning/1](https://github.com/kampalli31/mend-sast-gradle-demo/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow only needs to read repository contents for the Mend SAST scan, the permissions should be set to `contents: read`. This ensures that the workflow operates securely and does not have unnecessary write access.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
